### PR TITLE
chore(deps): bump lodash to >=4.18.0 (Dependabot #116, #117)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11203,9 +11203,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "web-vitals": "^5.0.0"
   },
   "overrides": {
+    "lodash": ">=4.18.0",
     "shell-quote": ">=1.8.4",
     "react-router": ">=7.15.0",
     "qs": ">=6.15.2",


### PR DESCRIPTION
## What

Adds a `lodash` override (`>=4.18.0`, resolves to **4.18.1**, the latest) to the `client` workspace, remediating two transitive Dependabot alerts that came in via `react-scripts` 5.0.1 / CRA internals:

- **#116 HIGH** -- Code Injection via `_.template`
- **#117 MEDIUM** -- Prototype Pollution in `_.unset` / `_.omit`

Both fixed in lodash `>=4.18.0`. The override is merged into the existing `overrides` block (shell-quote, react-router, qs, postcss, etc. left untouched).

## Why an override

lodash is a transitive dep (no direct `lodash` in `dependencies`), so a top-level `overrides` entry is the correct mechanism to force the resolved version across the tree.

## Verification

- `client/package-lock.json` resolves `node_modules/lodash` to `4.18.1`; no `lodash-4.17.x` references remain in the lock.
- `npm install` completed cleanly (no peer-dep conflicts, no `--legacy-peer-deps` needed).
- **`CI=true npm run build`** (CRA, warnings-as-errors -- matches the "Client Build" CI job): **compiled successfully**. lodash 4.18.1 is the first release after years at 4.17.21 and carries behavior changes, but nothing CRA/react-scripts relies on broke. Bundle size unchanged (main.js +791 B gzip).
- Standalone `lodash.debounce` / `lodash.merge` / etc. are separate packages, not in scope of these alerts, and left as-is.