### PR TITLE
fix: /alumni route crashes — missing loader for useLoaderData

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
   client-build:
     name: Client Build
     runs-on: ubuntu-latest
-    continue-on-error: true # pre-existing: case-sensitive import fails on Linux
     defaults:
       run:
         working-directory: client

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,7 +6,7 @@ import Home from "./pages/home/home.jsx";
 import About from "./pages/about/about.jsx";
 import Contact from "./pages/contact/contact.jsx";
 import Students from "./pages/Students/Students.jsx";
-import Alumni from "./pages/Alumni/Alumni.jsx";
+import Alumni, { loader as alumniLoader } from "./pages/Alumni/Alumni.jsx";
 import Authentication from "./pages/Authentication/Authentication";
 import ErrorPage from "./pages/Error/ErrorPage.jsx";
 import Mode from "./components/mode/mode.jsx";
@@ -34,7 +34,7 @@ function App() {
         { path: "/about", element: <About /> },
         { path: "/contact", element: <Contact /> },
         { path: "/students", element: <Students /> },
-        { path: "/alumni", element: <Alumni /> },
+        { path: "/alumni", element: <Alumni />, loader: alumniLoader },
         { path: "/profile", element: <Profile /> },
         { path: "/crcell", element: <CrCell /> },
         { path: "/placementcell", element: <PlacementCell /> },

--- a/client/src/pages/Error/ErrorPage.jsx
+++ b/client/src/pages/Error/ErrorPage.jsx
@@ -1,10 +1,21 @@
 import React from "react";
-import { useRouteError } from "react-router-dom";
+import { useRouteError, isRouteErrorResponse } from "react-router-dom";
 import PageContent from "../../components/PageContent/PageContent";
 
 const ErrorPage = () => {
   const error = useRouteError();
-  return <PageContent title={error.title} message={error.message} />;
+
+  let title = "An error occurred!";
+  let message = "Something went wrong.";
+
+  if (isRouteErrorResponse(error)) {
+    title = `${error.status} ${error.statusText}`;
+    message = typeof error.data === "string" ? error.data : message;
+  } else if (error instanceof Error) {
+    message = error.message;
+  }
+
+  return <PageContent title={title} message={message} />;
 };
 
 export default ErrorPage;


### PR DESCRIPTION
Small, low-risk correctness fixes.

### 1. `/alumni` route crashed — missing loader
`Alumni.jsx` calls `useLoaderData().users`, but the `/alumni` route registered no loader, so data was `undefined` and the page threw. Wired the `loader` already exported by `Alumni.jsx` into the route.

### 2. Error page rendered blank on 404 / route errors
`ErrorPage` read `error.title` / `error.message`, but react-router v7 hands `useRouteError()` an `ErrorResponse` (`status`/`statusText`/`data`) for 404s or a thrown `Error`. Neither shape has `.title`, so every routing error showed an empty page. Now uses `isRouteErrorResponse` to show the status line and data, falling back to `error.message` for thrown Errors.

### 3. CI: client build gates PRs again
The Client Build job carried `continue-on-error: true` justified by a case-sensitive import break — that was fixed in #404, and `CI=true npm run build` now passes locally. Dropped the flag so a broken client build fails CI instead of being silently swallowed.

Verified: `CI=true react-scripts build` compiles successfully; `node --check server.js` passes.